### PR TITLE
protect query field and redirect if request is still made

### DIFF
--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -47,10 +47,7 @@ class BusinessesController < ApplicationController
   end
 
   def search
-    @businesses = Business.where(
-      'LOWER(name) LIKE ?',
-      "%#{search_param.downcase}%"
-    ).order(:name)
+    @businesses = Business.search(search_param)
 
     if @businesses.empty?
       flash[:success] = 'No results found.'

--- a/app/controllers/businesses_controller.rb
+++ b/app/controllers/businesses_controller.rb
@@ -3,7 +3,6 @@
 class BusinessesController < ApplicationController
   before_action :authenticate_admin!, only: %w[new create edit update destroy]
   before_action :set_business, only: %w[show edit update destroy]
-  before_action :redirect_if_search_param_missing, only: :search
 
   def index
     @businesses = Business.order(:name)
@@ -48,13 +47,10 @@ class BusinessesController < ApplicationController
 
   def search
     @businesses = Business.search(search_param)
-
-    if @businesses.empty?
-      flash[:success] = 'No results found.'
-      redirect_to businesses_path
-    else
-      render :index
-    end
+    render :index
+  rescue ArgumentError
+    flash[:success] = 'No results found.'
+    redirect_to businesses_path
   end
 
   private
@@ -65,10 +61,6 @@ class BusinessesController < ApplicationController
 
   def search_param
     params[:q]
-  end
-
-  def redirect_if_search_param_missing
-    redirect_to businesses_path && return if search_param.blank?
   end
 
   def business_params

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -5,4 +5,8 @@ class Business < ApplicationRecord
   has_many :coupons, dependent: :delete_all
 
   validates :name, presence: true, uniqueness: true
+
+  scope :search, lambda { |search_param|
+    where('LOWER(name) LIKE ?', "%#{search_param.downcase}%").order(:name)
+  }
 end

--- a/app/models/business.rb
+++ b/app/models/business.rb
@@ -7,6 +7,8 @@ class Business < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   scope :search, lambda { |search_param|
+    raise ArgumentError if search_param.blank?
+
     where('LOWER(name) LIKE ?', "%#{search_param.downcase}%").order(:name)
   }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
         <li class="nav-item active">
 
           <%= form_tag '/search', method: :get, class: 'form-inline my-2 my-lg-0' do %>
-            <%= text_field_tag :q, params[:q], class: 'form-control mr-sm-2', placeholder: 'Search by Business' %>
+            <%= text_field_tag :q, params[:q], required: true, class: 'form-control mr-sm-2', placeholder: 'Search by Business' %>
             <%= submit_tag 'Search', name: nil, class: 'btn btn-northcenter my-2 my-sm-0' %>
           <% end %>
         </li>

--- a/spec/controllers/businesses/search_spec.rb
+++ b/spec/controllers/businesses/search_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe BusinessesController, type: :controller do
       let(:params) { { q: '' } }
 
       it 'redirects to the index action' do
-        expect(response).to render_template(:index)
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/spec/controllers/businesses/search_spec.rb
+++ b/spec/controllers/businesses/search_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BusinessesController, type: :controller do
     context 'when the query string is empty' do
       let(:params) { { q: '' } }
 
-      it 'redirects to the index action if the query is an empty string' do
+      it 'redirects to the index action' do
         expect(response).to render_template(:index)
       end
     end

--- a/spec/controllers/businesses/search_spec.rb
+++ b/spec/controllers/businesses/search_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BusinessesController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  describe 'GET #search' do
+    subject(:search) { get :search, params: { q: 'zZa' } }
+
+    let!(:business_b) { create(:business, :with_coupons, name: 'Pizza by Alfredo') }
+    let!(:business_a) { create(:business, :with_coupons, name: 'Piazza Del Tormini') }
+    let!(:business_c) { create(:business, :with_coupons, name: 'Duley Dentistry') }
+
+    before do
+      search
+    end
+
+    it 'assigns @businesses in the correct order' do
+      expect(assigns(:businesses)).to eq([business_a, business_b])
+    end
+
+    it 'renders the index view' do
+      expect(response).to render_template(:index)
+    end
+
+    context 'when the query string is empty' do
+      subject(:search) { get :search, params: { q: '' } }
+
+      it 'redirects to the index action if the query is an empty string' do
+        expect(response).to render_template(:index)
+      end
+    end
+  end
+end

--- a/spec/controllers/businesses/search_spec.rb
+++ b/spec/controllers/businesses/search_spec.rb
@@ -3,18 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe BusinessesController, type: :controller do
-  include Devise::Test::ControllerHelpers
-
   describe 'GET #search' do
-    subject(:search) { get :search, params: { q: 'zZa' } }
+    subject(:search) { get :search, params: params }
 
     let!(:business_b) { create(:business, :with_coupons, name: 'Pizza by Alfredo') }
     let!(:business_a) { create(:business, :with_coupons, name: 'Piazza Del Tormini') }
     let!(:business_c) { create(:business, :with_coupons, name: 'Duley Dentistry') }
 
-    before do
-      search
-    end
+    let(:params) { { q: 'zZa' } }
+
+    before { search }
 
     it 'assigns @businesses in the correct order' do
       expect(assigns(:businesses)).to eq([business_a, business_b])
@@ -25,7 +23,7 @@ RSpec.describe BusinessesController, type: :controller do
     end
 
     context 'when the query string is empty' do
-      subject(:search) { get :search, params: { q: '' } }
+      let(:params) { { q: '' } }
 
       it 'redirects to the index action if the query is an empty string' do
         expect(response).to render_template(:index)

--- a/spec/models/business_spec.rb
+++ b/spec/models/business_spec.rb
@@ -3,5 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Business, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '.search' do
+    let!(:business_b) { create(:business, :with_coupons, name: 'Pizza by Alfredo') }
+    let!(:business_a) { create(:business, :with_coupons, name: 'Piazza Del Tormini') }
+    let!(:business_c) { create(:business, :with_coupons, name: 'Duley Dentistry') }
+
+    let(:search_param) { 'zZa' }
+
+    it 'returns the matching businesses' do
+      expect(Business.search(search_param)).to eq([business_a, business_b])
+    end
+  end
 end

--- a/spec/models/business_spec.rb
+++ b/spec/models/business_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Business, type: :model do
   describe '.search' do
+    subject(:search) { described_class.search(search_param) }
+
     let!(:business_b) { create(:business, :with_coupons, name: 'Pizza by Alfredo') }
     let!(:business_a) { create(:business, :with_coupons, name: 'Piazza Del Tormini') }
     let!(:business_c) { create(:business, :with_coupons, name: 'Duley Dentistry') }
@@ -11,7 +13,15 @@ RSpec.describe Business, type: :model do
     let(:search_param) { 'zZa' }
 
     it 'returns the matching businesses' do
-      expect(Business.search(search_param)).to eq([business_a, business_b])
+      expect(search).to eq([business_a, business_b])
+    end
+
+    context 'when search_param is blank' do
+      let(:search_param) { '' }
+
+      it 'raises an ArgumentError' do
+        expect { search }.to raise_exception(ArgumentError)
+      end
     end
   end
 end


### PR DESCRIPTION
new behavior for searching with empty strings

First off, the front end will lock it down and prevent submission but in case a get request is still made somehow, the app will redirect to the index view